### PR TITLE
[integritee-runtime] bump authoring_version

### DIFF
--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -88,7 +88,7 @@ mod weights;
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("integritee-parachain"),
 	impl_name: create_runtime_str!("integritee-full"),
-	authoring_version: 1,
+	authoring_version: 2,
 	spec_version: 10,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,


### PR DESCRIPTION
To match crate versions